### PR TITLE
Un-commented the admin menu from wp-strava.php

### DIFF
--- a/wp-strava.php
+++ b/wp-strava.php
@@ -36,7 +36,7 @@ if(file_exists(dirname(__FILE__) . '/lang/' . get_locale() . '.mo' ) ) {
 }
 
 // Creating the admin menu options
-//add_action('admin_menu', '\WP\Strava\wp_strava_plugin_menu');
+add_action('admin_menu', '\WP\Strava\wp_strava_plugin_menu');
 
 function wp_strava_plugin_menu() {
 	add_options_page('WP Strava Options', 'WP Strava', 'manage_options', '\WP\Strava\wp-strava-options', '\WP\Strava\wp_strava_plugin_options');


### PR DESCRIPTION
If you installed the plugin, the menu to retrieve your token would not appear because it is commented.

Thanks for the nice work on the plugin.
