### PR TITLE
Fix CSS to avoid conflict with non WP-Strava tables

### DIFF
--- a/css/wp-strava.css
+++ b/css/wp-strava.css
@@ -58,7 +58,12 @@ only screen and (max-width: 760px),
 (min-device-width: 768px) and (max-device-width: 1024px)  {
 
 	/* Force table to not be like tables anymore */
-	.activity-details-table table, thead, tbody, th, td, tr {
+	.activity-details-table table,
+	.activity-details-table thead,
+	.activity-details-table tbody,
+	.activity-details-table th,
+	.activity-details-table td,
+	.activity-details-table tr {
 		display: block;
 	}
 


### PR DESCRIPTION
The current CSS file cause issue with other tables on the page when viewing on mobile. Adding .activity-details-table to fix that.